### PR TITLE
New OpenAPI schema for search endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -60,14 +60,8 @@ paths:
             application/json:
               schema:
                 anyOf:
-                - type: array
-                  items:
-                    type: object
-                    additionalProperties:
-                      type: object
-                      additionalProperties:
-                        type: string
-                - type: string
+                - $ref: '#/components/schemas/SearchResponse'
+                - type: 'null'
                 title: Response Search Graph Api V0 Graph Get
         '422':
           description: Validation Error
@@ -99,6 +93,38 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    ResponseResults:
+      properties:
+        bindings:
+          items: {}
+          type: array
+          title: Bindings
+      type: object
+      required:
+      - bindings
+      title: ResponseResults
+    ResposneHead:
+      properties:
+        vars:
+          items:
+            type: string
+          type: array
+          title: Vars
+      type: object
+      required:
+      - vars
+      title: ResposneHead
+    SearchResponse:
+      properties:
+        head:
+          $ref: '#/components/schemas/ResposneHead'
+        results:
+          $ref: '#/components/schemas/ResponseResults'
+      type: object
+      required:
+      - head
+      - results
+      title: SearchResponse
     ValidationError:
       properties:
         loc:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -59,10 +59,7 @@ paths:
           content:
             application/json:
               schema:
-                anyOf:
-                - $ref: '#/components/schemas/SearchResponse'
-                - type: 'null'
-                title: Response Search Graph Api V0 Graph Get
+                $ref: '#/components/schemas/SearchResponse'
         '422':
           description: Validation Error
           content:
@@ -125,6 +122,33 @@ components:
       - head
       - results
       title: SearchResponse
+      example:
+        head:
+          vars:
+          - sub
+          - pred
+          - obj
+        results:
+          bindings:
+          - obj:
+              type: uri
+              value: http://data.kasabi.com/dataset/cheese/schema/Cheese
+            pred:
+              type: uri
+              value: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+            sub:
+              type: uri
+              value: http://data.kasabi.com/dataset/cheese/halloumi
+          - obj:
+              type: literal
+              value: Halloumi
+              xml:lang: el
+            pred:
+              type: uri
+              value: http://www.w3.org/2000/01/rdf-schema#label
+            sub:
+              type: uri
+              value: http://data.kasabi.com/dataset/cheese/halloumi
     ValidationError:
       properties:
         loc:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -41,6 +41,7 @@ paths:
       tags:
       - Graph
       summary: Search Graph
+      description: Execute SPARQL search query and return a response in JSON-LD format.
       operationId: search_graph_api_v0_graph_get
       parameters:
       - name: query
@@ -48,11 +49,11 @@ paths:
         required: true
         schema:
           type: string
-          description: Request body must be a SELECT SPARQL query. It must be compatible
-            with GLACIATION metadata upper ontology.
+          description: SELECT query in SPARQL language. It must be compatible with
+            GLACIATION metadata upper ontology.
           title: Query
-        description: Request body must be a SELECT SPARQL query. It must be compatible
-          with GLACIATION metadata upper ontology.
+        description: SELECT query in SPARQL language. It must be compatible with GLACIATION
+          metadata upper ontology.
       responses:
         '200':
           description: Successful Response

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -43,14 +43,14 @@ paths:
       summary: Search Graph
       operationId: search_graph_api_v0_graph_get
       parameters:
-      - name: SPARQLquery
+      - name: query
         in: query
         required: true
         schema:
           type: string
           description: Request body must be a SELECT SPARQL query. It must be compatible
             with GLACIATION metadata upper ontology.
-          title: Sparqlquery
+          title: Query
         description: Request body must be a SELECT SPARQL query. It must be compatible
           with GLACIATION metadata upper ontology.
       responses:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -37,12 +37,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/v0/graph/search:
     get:
       tags:
       - Graph
       summary: Search Graph
-      operationId: search_graph_api_v0_graph_search_get
+      operationId: search_graph_api_v0_graph_get
       parameters:
       - name: SPARQLquery
         in: query
@@ -69,7 +68,7 @@ paths:
                       additionalProperties:
                         type: string
                 - type: string
-                title: Response Search Graph Api V0 Graph Search Get
+                title: Response Search Graph Api V0 Graph Get
         '422':
           description: Validation Error
           content:

--- a/server/.flake8
+++ b/server/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 88
+max-line-length = 120
 extend-ignore = E203, E704
 exclude =
   .git,

--- a/server/app/consts.py
+++ b/server/app/consts.py
@@ -1,6 +1,14 @@
 from enum import Enum
 
+from app.schemas import ResponseResults, ResposneHead, SearchResponse
+
 
 class TagEnum(Enum):
     GRAPH = "Graph"
     MONITORING = "Monitoring"
+
+
+EMPTY_SEARCH_RESPONSE = SearchResponse(
+    head=ResposneHead(vars=[]),
+    results=ResponseResults(bindings=[]),
+)

--- a/server/app/routers.py
+++ b/server/app/routers.py
@@ -1,17 +1,14 @@
-from typing import Annotated, Any
-
 from io import StringIO
 from json import dumps
 
-from fastapi import APIRouter, Body
+from fastapi import APIRouter
 from rdflib import Graph
-from SPARQLWrapper.SmartWrapper import Bindings
 from starlette.responses import RedirectResponse
 from starlette.status import HTTP_303_SEE_OTHER
 
 from app.consts import EMPTY_SEARCH_RESPONSE, TagEnum
 from app.FusekiCommunicator import FusekiCommunicatior
-from app.schemas import SearchResponse, SPARQLQuery
+from app.schemas import SearchResponse, SPARQLQuery, UpdateRequestBody
 
 router = APIRouter(tags=[TagEnum.GRAPH])
 
@@ -37,15 +34,7 @@ async def read_root() -> RedirectResponse:
     "/api/v0/graph",
 )
 async def update_graph(
-    body: Annotated[
-        dict[str, Any],
-        Body(
-            description=(
-                "Request body must be in JSON-LD format. "
-                "It must be compatible with GLACIATION metadata upper ontology."
-            ),
-        ),
-    ]
+    body: UpdateRequestBody,
 ) -> str:
     """Update Distributed Knowledge Graph"""
     g = Graph()
@@ -70,18 +59,17 @@ async def update_graph(
 async def search_graph(
     query: SPARQLQuery,
 ) -> SearchResponse:
-    result = fuseki.read_query(query)
-    if type(result) is Bindings:
-        # bindings = []
-        # for item in result.bindings:
-        #     new_item = {}
-        #     for key in item:
-        #         if hasattr(item[key], "value") and hasattr(item[key], "type"):
-        #             new_item[key] = {"value": item[key].value, "type": item[key].type}
-        #     bindings.append(new_item)
-        # return bindings
-        return (
-            EMPTY_SEARCH_RESPONSE  # Uncomment and fix code above, then delete this line
-        )
-    else:
-        return EMPTY_SEARCH_RESPONSE
+    """Execute SPARQL search query and return a response in JSON-LD format."""
+    # result = fuseki.read_query(query)
+    # if type(result) is Bindings:
+    #     bindings = []
+    #     for item in result.bindings:
+    #         new_item = {}
+    #         for key in item:
+    #             if hasattr(item[key], "value") and hasattr(item[key], "type"):
+    #                 new_item[key] = {"value": item[key].value, "type": item[key].type}
+    #         bindings.append(new_item)
+    #     return bindings
+    # else:
+    #     return str(result)
+    return EMPTY_SEARCH_RESPONSE  # Fix code above, then delete this line

--- a/server/app/routers.py
+++ b/server/app/routers.py
@@ -1,16 +1,16 @@
-from typing import Annotated, Any, Dict, List
+from typing import Annotated, Any
 
 from io import StringIO
 from json import dumps
 
 from fastapi import APIRouter, Body, Query
 from rdflib import Graph
-from SPARQLWrapper.SmartWrapper import Bindings
 from starlette.responses import RedirectResponse
 from starlette.status import HTTP_303_SEE_OTHER
 
 from app.consts import TagEnum
 from app.FusekiCommunicator import FusekiCommunicatior
+from app.schemas import SearchResponse
 
 router = APIRouter(tags=[TagEnum.GRAPH])
 
@@ -76,16 +76,17 @@ async def search_graph(
             ),
         ),
     ]
-) -> List[Dict[str, Dict[str, str]]] | str:
-    result = fuseki.read_query(SPARQLquery)
-    if type(result) is Bindings:
-        bindings = []
-        for item in result.bindings:
-            new_item = {}
-            for key in item:
-                if hasattr(item[key], "value") and hasattr(item[key], "type"):
-                    new_item[key] = {"value": item[key].value, "type": item[key].type}
-            bindings.append(new_item)
-        return bindings
-    else:
-        return str(result)
+) -> SearchResponse | None:
+    # result = fuseki.read_query(SPARQLquery)
+    # if type(result) is Bindings:
+    #     bindings = []
+    #     for item in result.bindings:
+    #         new_item = {}
+    #         for key in item:
+    #             if hasattr(item[key], "value") and hasattr(item[key], "type"):
+    #                 new_item[key] = {"value": item[key].value, "type": item[key].type}
+    #         bindings.append(new_item)
+    #     return bindings
+    # else:
+    #     return str(result)
+    return None  # Delete me!

--- a/server/app/routers.py
+++ b/server/app/routers.py
@@ -64,7 +64,7 @@ async def update_graph(
 
 
 @router.get(
-    "/api/v0/graph/search",
+    "/api/v0/graph",
 )
 async def search_graph(
     SPARQLquery: Annotated[

--- a/server/app/routers.py
+++ b/server/app/routers.py
@@ -3,14 +3,14 @@ from typing import Annotated, Any
 from io import StringIO
 from json import dumps
 
-from fastapi import APIRouter, Body, Query
+from fastapi import APIRouter, Body
 from rdflib import Graph
 from starlette.responses import RedirectResponse
 from starlette.status import HTTP_303_SEE_OTHER
 
 from app.consts import TagEnum
 from app.FusekiCommunicator import FusekiCommunicatior
-from app.schemas import SearchResponse
+from app.schemas import SearchResponse, SPARQLQuery
 
 router = APIRouter(tags=[TagEnum.GRAPH])
 
@@ -67,17 +67,9 @@ async def update_graph(
     "/api/v0/graph",
 )
 async def search_graph(
-    SPARQLquery: Annotated[
-        str,
-        Query(
-            description=(
-                "Request body must be a SELECT SPARQL query. "
-                "It must be compatible with GLACIATION metadata upper ontology."
-            ),
-        ),
-    ]
+    query: SPARQLQuery,
 ) -> SearchResponse | None:
-    # result = fuseki.read_query(SPARQLquery)
+    # result = fuseki.read_query(query)
     # if type(result) is Bindings:
     #     bindings = []
     #     for item in result.bindings:

--- a/server/app/routers.py
+++ b/server/app/routers.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any
 from io import StringIO
 from json import dumps
 
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, HTTPException
 from rdflib import Graph
 from starlette.responses import RedirectResponse
 from starlette.status import HTTP_303_SEE_OTHER
@@ -68,7 +68,7 @@ async def update_graph(
 )
 async def search_graph(
     query: SPARQLQuery,
-) -> SearchResponse | None:
+) -> SearchResponse:
     # result = fuseki.read_query(query)
     # if type(result) is Bindings:
     #     bindings = []
@@ -81,4 +81,6 @@ async def search_graph(
     #     return bindings
     # else:
     #     return str(result)
-    return None  # Delete me!
+    raise HTTPException(
+        status_code=422, detail="Unknown error"
+    )  # Uncomment and fix code above, then delete this line.

--- a/server/app/routers.py
+++ b/server/app/routers.py
@@ -3,12 +3,13 @@ from typing import Annotated, Any
 from io import StringIO
 from json import dumps
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Body
 from rdflib import Graph
+from SPARQLWrapper.SmartWrapper import Bindings
 from starlette.responses import RedirectResponse
 from starlette.status import HTTP_303_SEE_OTHER
 
-from app.consts import TagEnum
+from app.consts import EMPTY_SEARCH_RESPONSE, TagEnum
 from app.FusekiCommunicator import FusekiCommunicatior
 from app.schemas import SearchResponse, SPARQLQuery
 
@@ -69,18 +70,18 @@ async def update_graph(
 async def search_graph(
     query: SPARQLQuery,
 ) -> SearchResponse:
-    # result = fuseki.read_query(query)
-    # if type(result) is Bindings:
-    #     bindings = []
-    #     for item in result.bindings:
-    #         new_item = {}
-    #         for key in item:
-    #             if hasattr(item[key], "value") and hasattr(item[key], "type"):
-    #                 new_item[key] = {"value": item[key].value, "type": item[key].type}
-    #         bindings.append(new_item)
-    #     return bindings
-    # else:
-    #     return str(result)
-    raise HTTPException(
-        status_code=422, detail="Unknown error"
-    )  # Uncomment and fix code above, then delete this line.
+    result = fuseki.read_query(query)
+    if type(result) is Bindings:
+        # bindings = []
+        # for item in result.bindings:
+        #     new_item = {}
+        #     for key in item:
+        #         if hasattr(item[key], "value") and hasattr(item[key], "type"):
+        #             new_item[key] = {"value": item[key].value, "type": item[key].type}
+        #     bindings.append(new_item)
+        # return bindings
+        return (
+            EMPTY_SEARCH_RESPONSE  # Uncomment and fix code above, then delete this line
+        )
+    else:
+        return EMPTY_SEARCH_RESPONSE

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -16,6 +16,46 @@ class SearchResponse(BaseModel):
     head: ResposneHead
     results: ResponseResults
 
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "head": {"vars": ["sub", "pred", "obj"]},
+                "results": {
+                    "bindings": [
+                        {
+                            "sub": {
+                                "type": "uri",
+                                "value": "http://data.kasabi.com/dataset/cheese/halloumi",
+                            },
+                            "pred": {
+                                "type": "uri",
+                                "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                            },
+                            "obj": {
+                                "type": "uri",
+                                "value": "http://data.kasabi.com/dataset/cheese/schema/Cheese",
+                            },
+                        },
+                        {
+                            "sub": {
+                                "type": "uri",
+                                "value": "http://data.kasabi.com/dataset/cheese/halloumi",
+                            },
+                            "pred": {
+                                "type": "uri",
+                                "value": "http://www.w3.org/2000/01/rdf-schema#label",
+                            },
+                            "obj": {
+                                "type": "literal",
+                                "xml:lang": "el",
+                                "value": "Halloumi",
+                            },
+                        },
+                    ]
+                },
+            }
+        }
+
 
 SPARQLQuery = Annotated[
     str,

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class ResposneHead(BaseModel):
+    vars: list[str]
+
+
+class ResponseResults(BaseModel):
+    bindings: list[object]
+
+
+class SearchResponse(BaseModel):
+    head: ResposneHead
+    results: ResponseResults

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -1,3 +1,6 @@
+from typing import Annotated
+
+from fastapi import Query
 from pydantic import BaseModel
 
 
@@ -12,3 +15,14 @@ class ResponseResults(BaseModel):
 class SearchResponse(BaseModel):
     head: ResposneHead
     results: ResponseResults
+
+
+SPARQLQuery = Annotated[
+    str,
+    Query(
+        description=(
+            "Request body must be a SELECT SPARQL query. "
+            "It must be compatible with GLACIATION metadata upper ontology."
+        ),
+    ),
+]

--- a/server/app/schemas.py
+++ b/server/app/schemas.py
@@ -1,6 +1,6 @@
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import Query
+from fastapi import Body, Query
 from pydantic import BaseModel
 
 
@@ -57,11 +57,21 @@ class SearchResponse(BaseModel):
         }
 
 
+UpdateRequestBody = Annotated[
+    dict[str, Any],
+    Body(
+        description=(
+            "Request body must be in JSON-LD format. "
+            "It must be compatible with GLACIATION metadata upper ontology."
+        ),
+    ),
+]
+
 SPARQLQuery = Annotated[
     str,
     Query(
         description=(
-            "Request body must be a SELECT SPARQL query. "
+            "SELECT query in SPARQL language. "
             "It must be compatible with GLACIATION metadata upper ontology."
         ),
     ),

--- a/server/app/tests/test_routers.py
+++ b/server/app/tests/test_routers.py
@@ -34,7 +34,7 @@ def test__search_graph__redirected() -> None:
     response = client.get(
         "/api/v0/graph",
         params={
-            "SPARQLquery": """
+            "query": """
             SELECT ?subject ?predicate ?object
             WHERE {
                 ?subject ?predicate ?object

--- a/server/app/tests/test_routers.py
+++ b/server/app/tests/test_routers.py
@@ -32,7 +32,7 @@ def test__update_graph__redirected() -> None:
 
 def test__search_graph__redirected() -> None:
     response = client.get(
-        "/api/v0/graph/search",
+        "/api/v0/graph",
         params={
             "SPARQLquery": """
             SELECT ?subject ?predicate ?object


### PR DESCRIPTION
Last time HIRO and LAKE agreed that I will update OpenAPI schema for Search endpoint. It's done now.

1. I changed an output schema and added an example.
2. Changed URL of endpoint "GET /graph/search" to "GET /graph" for compatibility with REST API best practices.

I commented out existing data transformation because it is not compatible with our new output format. I could not leave it because Mypy validator does not pass. I do not have time to modify this logic and test it (and we have zero unit tests implemented). 

@fpetke, now it's your turn to update your logic to fill an output object with data. I recommend to make a new pull-request. Once you approve my pull-request, feel free to merge it.